### PR TITLE
Fix build problems and integrate with manifold-engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ jar {
 repositories {
   mavenCentral()
   jcenter()
+  mavenLocal()
   maven {
     name 'Manifold release repository'
     url 'http://manifold-lang.org/releases'
@@ -40,7 +41,7 @@ dependencies {
   testCompile 'junit:junit:4.11'
   compile 'log4j:log4j:1.2.16'
   compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
-  compile 'org.manifold:manifold-core:0.9.+'
+  compile 'org.manifold:manifold-core:0.11.+'
 }
 
 buildscript {

--- a/src/main/resources/META-INF/services/org.manifold.compiler.Backend
+++ b/src/main/resources/META-INF/services/org.manifold.compiler.Backend
@@ -1,0 +1,1 @@
+org.manifold.compiler.back.microfluidics.MicrofluidicsBackend


### PR DESCRIPTION
manifold-engine looks for classes implementing `Frontend` and `Backend` using a `ServiceLoader`. Service providers need to be declared in `META-INF` in order for the `ServiceLoader` to see them.
