### PR TITLE
Make all code conform to style guide

### DIFF
--- a/src/main/java/org/manifold/compiler/back/microfluidics/smt2/Macros.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/smt2/Macros.java
@@ -26,13 +26,13 @@ public class Macros {
   // "total flow in = total flow out"
   // this is difficult because the actual flow direction may be backwards
   // with respect to the expected direction
-  public static List<SExpression> generateConservationOfFlow(Schematic schematic,
-      List<PortValue> connectedPorts) {
+  public static List<SExpression> generateConservationOfFlow(
+      Schematic schematic, List<PortValue> connectedPorts) {
     List<SExpression> flowRatesIn = new LinkedList<SExpression>();
     List<SExpression> flowRatesOut = new LinkedList<SExpression>();
     
-    List<SExpression> flowRatesIn_WorstCase = new LinkedList<SExpression>();
-    List<SExpression> flowRatesOut_WorstCase = new LinkedList<SExpression>();
+    List<SExpression> flowRatesInWorstCase = new LinkedList<SExpression>();
+    List<SExpression> flowRatesOutWorstCase = new LinkedList<SExpression>();
     
     for (PortValue port : connectedPorts) {
       ConnectionValue channel = getConnection(schematic, port);
@@ -49,21 +49,23 @@ public class Macros {
       }
       Symbol flowRate = SymbolNameGenerator
           .getsym_ChannelFlowRate(schematic, channel);
-      Symbol flowRate_WorstCase = SymbolNameGenerator
+      Symbol flowRateWorstCase = SymbolNameGenerator
           .getsym_ChannelFlowRate_WorstCase(schematic, channel);
       if (connectedIntoJunction) {
         // flow rate is positive into the junction
         flowRatesIn.add(flowRate);
-        flowRatesIn_WorstCase.add(flowRate_WorstCase);
+        flowRatesInWorstCase.add(flowRateWorstCase);
       } else {
         // flow rate is positive out of the junction
         flowRatesOut.add(flowRate);
-        flowRatesOut_WorstCase.add(flowRate_WorstCase);
+        flowRatesOutWorstCase.add(flowRateWorstCase);
       }
     }
     List<SExpression> exprs = new LinkedList<>();
-    exprs.add(QFNRA.assertEqual(QFNRA.add(flowRatesIn), QFNRA.add(flowRatesOut)));
-    exprs.add(QFNRA.assertEqual(QFNRA.add(flowRatesIn_WorstCase), QFNRA.add(flowRatesOut_WorstCase)));
+    exprs.add(QFNRA.assertEqual(QFNRA.add(flowRatesIn),
+        QFNRA.add(flowRatesOut)));
+    exprs.add(QFNRA.assertEqual(QFNRA.add(flowRatesInWorstCase),
+        QFNRA.add(flowRatesOutWorstCase)));
     return exprs;
   }
   

--- a/src/main/java/org/manifold/compiler/back/microfluidics/smt2/SymbolNameGenerator.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/smt2/SymbolNameGenerator.java
@@ -123,8 +123,8 @@ public class SymbolNameGenerator {
     return new Symbol(chName.concat("_droplet_volume"));
   }
   
-  public static Symbol getsym_ChannelDropletVolume_WorstCase(Schematic schematic,
-      ConnectionValue ch) {
+  public static Symbol getsym_ChannelDropletVolume_WorstCase(
+      Schematic schematic, ConnectionValue ch) {
     String chName = schematic.getConnectionName(ch);
     return new Symbol(chName.concat("_droplet_volume_worst_case"));
   }

--- a/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/FluidEntryExitDeviceStrategy.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/FluidEntryExitDeviceStrategy.java
@@ -75,7 +75,8 @@ public class FluidEntryExitDeviceStrategy extends TranslationStrategy {
             node.getPort("output"))));
     // constraint: port pressure >= 0
     exprs.add(QFNRA.assertLessThanEqual(new Numeral(0), 
-        SymbolNameGenerator.getSym_PortPressure(schematic, node.getPort("output"))));
+        SymbolNameGenerator.getSym_PortPressure(schematic,
+            node.getPort("output"))));
     
     // the viscosity in the channel connected to output
     // is the viscosity given at the entry
@@ -100,7 +101,8 @@ public class FluidEntryExitDeviceStrategy extends TranslationStrategy {
     
     // constraint: port pressure >= 0
     exprs.add(QFNRA.assertLessThanEqual(new Numeral(0), 
-        SymbolNameGenerator.getSym_PortPressure(schematic, node.getPort("input"))));
+        SymbolNameGenerator.getSym_PortPressure(schematic,
+            node.getPort("input"))));
     
     return exprs;
   }

--- a/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/SimplePressureFlowStrategy.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/SimplePressureFlowStrategy.java
@@ -50,8 +50,9 @@ public class SimplePressureFlowStrategy extends PressureFlowStrategy {
     
     if (performWorstCaseAnalysis) {
       // now declare a "worst case" flow rate, i.e. with maximum # of droplets
-      Symbol chV_WorstCase = SymbolNameGenerator.getsym_ChannelFlowRate_WorstCase(schematic, conn);
-      exprs.add(QFNRA.declareRealVariable(chV_WorstCase));
+      Symbol chVWorstCase = SymbolNameGenerator
+          .getsym_ChannelFlowRate_WorstCase(schematic, conn);
+      exprs.add(QFNRA.declareRealVariable(chVWorstCase));
       // the resistance in the worst case is (approximately)
       // equal to the base channel resistance plus
       // the number of droplets times the resistance of each droplet
@@ -59,13 +60,13 @@ public class SimplePressureFlowStrategy extends PressureFlowStrategy {
           .getsym_ChannelMaxDroplets(schematic, conn);
       Symbol dropletResistance = SymbolNameGenerator
           .getsym_ChannelDropletResistance(schematic, conn);
-      SExpression chR_WorstCase = QFNRA.add(chR, 
+      SExpression chRWorstCase = QFNRA.add(chR,
           QFNRA.multiply(nDroplets, dropletResistance));
       // assume pressures are the same as before,
       // but flow rates can change in the worst case
       // TODO is this right?
       exprs.add(QFNRA.assertEqual(QFNRA.subtract(p1, p2),
-          QFNRA.multiply(chV_WorstCase, chR_WorstCase)));
+          QFNRA.multiply(chVWorstCase, chRWorstCase)));
     }
     
     return exprs;

--- a/src/test/java/org/manifold/compiler/back/microfluidics/TestMicrofluidicsBackend.java
+++ b/src/test/java/org/manifold/compiler/back/microfluidics/TestMicrofluidicsBackend.java
@@ -88,14 +88,17 @@ public class TestMicrofluidicsBackend {
     schematic.addNode("junction0", junction);
     
     
-    ConnectionValue entryToJunction = UtilSchematicConstruction.instantiateChannel(
-        entry.getPort("output"), junction.getPort("continuous"));
+    ConnectionValue entryToJunction = UtilSchematicConstruction
+        .instantiateChannel(entry.getPort("output"),
+        junction.getPort("continuous"));
     schematic.addConnection("channelC", entryToJunction);
-    ConnectionValue disperseToJunction = UtilSchematicConstruction.instantiateChannel(
-        disperse.getPort("output"), junction.getPort("dispersed"));
+    ConnectionValue disperseToJunction = UtilSchematicConstruction
+        .instantiateChannel(disperse.getPort("output"),
+        junction.getPort("dispersed"));
     schematic.addConnection("channelD", disperseToJunction);
-    ConnectionValue junctionToExit = UtilSchematicConstruction.instantiateChannel(
-        junction.getPort("output"), exit.getPort("input"));
+    ConnectionValue junctionToExit = UtilSchematicConstruction
+        .instantiateChannel(junction.getPort("output"),
+        exit.getPort("input"));
     schematic.addConnection("channelE", junctionToExit);
     
     MicrofluidicsBackend backend = new MicrofluidicsBackend();


### PR DESCRIPTION
Most style guide issues involved lines over 80 characters and non-camelcase variable names.
