### PR TITLE
Refactor getConnection() into a SchematicUtil

### DIFF
--- a/src/main/java/org/manifold/compiler/back/microfluidics/SchematicUtil.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/SchematicUtil.java
@@ -1,0 +1,21 @@
+package org.manifold.compiler.back.microfluidics;
+
+import org.manifold.compiler.ConnectionValue;
+import org.manifold.compiler.PortValue;
+import org.manifold.compiler.middle.Schematic;
+
+public class SchematicUtil {
+
+  // Get the connection associated with this port.
+  // TODO this is VERY EXPENSIVE, find an optimization.
+  public static ConnectionValue getConnection(
+    Schematic schematic, PortValue port) {
+    for (ConnectionValue conn : schematic.getConnections().values()) {
+      if (conn.getFrom().equals(port) || conn.getTo().equals(port)) {
+        return conn;
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/org/manifold/compiler/back/microfluidics/smt2/Macros.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/smt2/Macros.java
@@ -6,21 +6,11 @@ import java.util.List;
 import org.manifold.compiler.ConnectionValue;
 import org.manifold.compiler.PortValue;
 import org.manifold.compiler.back.microfluidics.CodeGenerationError;
+import org.manifold.compiler.back.microfluidics.SchematicUtil;
 import org.manifold.compiler.middle.Schematic;
 
-public class Macros {
 
-  //get the connection associated with this port
-  // TODO this is VERY EXPENSIVE, find an optimization
-  protected static ConnectionValue getConnection(
-     Schematic schematic, PortValue port) {
-    for (ConnectionValue conn : schematic.getConnections().values()) {
-      if (conn.getFrom().equals(port) || conn.getTo().equals(port)) {
-        return conn;
-      }
-    }
-    return null;
-  }
+public class Macros {
   
   // generate an expression that describes the constraint
   // "total flow in = total flow out"
@@ -35,7 +25,7 @@ public class Macros {
     List<SExpression> flowRatesOut_WorstCase = new LinkedList<SExpression>();
     
     for (PortValue port : connectedPorts) {
-      ConnectionValue channel = getConnection(schematic, port);
+      ConnectionValue channel = SchematicUtil.getConnection(schematic, port);
       boolean connectedIntoJunction;
       // check which way the channel is connected
       if (channel.getFrom().equals(port)) {

--- a/src/main/java/org/manifold/compiler/back/microfluidics/strategies/multiphase/TJunctionDeviceStrategy.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/strategies/multiphase/TJunctionDeviceStrategy.java
@@ -11,6 +11,7 @@ import org.manifold.compiler.UndeclaredIdentifierException;
 import org.manifold.compiler.back.microfluidics.CodeGenerationError;
 import org.manifold.compiler.back.microfluidics.PrimitiveTypeTable;
 import org.manifold.compiler.back.microfluidics.ProcessParameters;
+import org.manifold.compiler.back.microfluidics.SchematicUtil;
 import org.manifold.compiler.back.microfluidics.TranslationStrategy;
 import org.manifold.compiler.back.microfluidics.smt2.Decimal;
 import org.manifold.compiler.back.microfluidics.smt2.Macros;
@@ -31,18 +32,6 @@ public class TJunctionDeviceStrategy extends TranslationStrategy {
     this.performWorstCaseAnalysis = performWorstCaseAnalysis;
   }
   
-  //get the connection associated with this port
-  // TODO this is VERY EXPENSIVE, find an optimization
-  protected ConnectionValue getConnection(
-     Schematic schematic, PortValue port) {
-    for (ConnectionValue conn : schematic.getConnections().values()) {
-      if (conn.getFrom().equals(port) || conn.getTo().equals(port)) {
-        return conn;
-      }
-    }
-    return null;
-  }
-  
   @Override
   protected List<SExpression> translationStep(Schematic schematic,
       ProcessParameters processParams, PrimitiveTypeTable typeTable) {
@@ -56,11 +45,11 @@ public class TJunctionDeviceStrategy extends TranslationStrategy {
       // pull connections out of the node
       try {
         // TODO refactor these into constants
-        ConnectionValue chContinuous = getConnection(
+        ConnectionValue chContinuous = SchematicUtil.getConnection(
             schematic, node.getPort("continuous"));
-        ConnectionValue chDispersed = getConnection(
+        ConnectionValue chDispersed = SchematicUtil.getConnection(
             schematic, node.getPort("dispersed"));
-        ConnectionValue chOutput = getConnection(
+        ConnectionValue chOutput = SchematicUtil.getConnection(
             schematic, node.getPort("output"));
         exprs.addAll(translateTJunction(schematic, node, 
             chContinuous, chDispersed, chOutput));

--- a/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/AnalyticalPressureFlowStrategy.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/AnalyticalPressureFlowStrategy.java
@@ -13,6 +13,7 @@ import org.manifold.compiler.UndeclaredIdentifierException;
 import org.manifold.compiler.back.microfluidics.CodeGenerationError;
 import org.manifold.compiler.back.microfluidics.PrimitiveTypeTable;
 import org.manifold.compiler.back.microfluidics.ProcessParameters;
+import org.manifold.compiler.back.microfluidics.SchematicUtil;
 import org.manifold.compiler.back.microfluidics.TranslationStrategy;
 import org.manifold.compiler.back.microfluidics.smt2.Decimal;
 import org.manifold.compiler.back.microfluidics.smt2.QFNRA;
@@ -22,17 +23,6 @@ import org.manifold.compiler.back.microfluidics.smt2.SymbolNameGenerator;
 import org.manifold.compiler.middle.Schematic;
 
 public class AnalyticalPressureFlowStrategy extends TranslationStrategy {
-
-  // get the connection associated with this port
-  // TODO this is VERY EXPENSIVE, find an optimization
-  protected ConnectionValue getConnection(Schematic schematic, PortValue port) {
-    for (ConnectionValue conn : schematic.getConnections().values()) {
-      if (conn.getFrom().equals(port) || conn.getTo().equals(port)) {
-        return conn;
-      }
-    }
-    return null;
-  }
   
   @Override
   protected List<SExpression> translationStep(Schematic schematic,
@@ -138,7 +128,8 @@ public class AnalyticalPressureFlowStrategy extends TranslationStrategy {
     ExpandedPath expansion = new ExpandedPath();
     PortValue nextPort = port;
     while (true) {
-      ConnectionValue nextConn = getConnection(schematic, nextPort);
+      ConnectionValue nextConn = SchematicUtil.getConnection(
+          schematic, nextPort);
       if (nextConn == null) {
         // TODO throw exception
       }

--- a/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/FluidEntryExitDeviceStrategy.java
+++ b/src/main/java/org/manifold/compiler/back/microfluidics/strategies/pressureflow/FluidEntryExitDeviceStrategy.java
@@ -12,6 +12,7 @@ import org.manifold.compiler.UndeclaredIdentifierException;
 import org.manifold.compiler.back.microfluidics.CodeGenerationError;
 import org.manifold.compiler.back.microfluidics.PrimitiveTypeTable;
 import org.manifold.compiler.back.microfluidics.ProcessParameters;
+import org.manifold.compiler.back.microfluidics.SchematicUtil;
 import org.manifold.compiler.back.microfluidics.TranslationStrategy;
 import org.manifold.compiler.back.microfluidics.smt2.Decimal;
 import org.manifold.compiler.back.microfluidics.smt2.Numeral;
@@ -22,18 +23,6 @@ import org.manifold.compiler.back.microfluidics.smt2.SymbolNameGenerator;
 import org.manifold.compiler.middle.Schematic;
 
 public class FluidEntryExitDeviceStrategy extends TranslationStrategy {
-
-//get the connection associated with this port
-  // TODO this is VERY EXPENSIVE, find an optimization
-  protected ConnectionValue getConnection(
-     Schematic schematic, PortValue port) {
-    for (ConnectionValue conn : schematic.getConnections().values()) {
-      if (conn.getFrom().equals(port) || conn.getTo().equals(port)) {
-        return conn;
-      }
-    }
-    return null;
-  }
   
   @Override
   protected List<SExpression> translationStep(Schematic schematic,
@@ -79,7 +68,8 @@ public class FluidEntryExitDeviceStrategy extends TranslationStrategy {
     
     // the viscosity in the channel connected to output
     // is the viscosity given at the entry
-    ConnectionValue ch = getConnection(schematic, node.getPort("output"));
+      ConnectionValue ch = SchematicUtil.getConnection(
+        schematic, node.getPort("output"));
     Symbol mu = SymbolNameGenerator.getsym_ChannelViscosity(schematic, ch);
     RealValue viscosity = (RealValue) node.getAttribute("viscosity");
     exprs.add(QFNRA.assertEqual(mu, new Decimal(viscosity.toDouble())));


### PR DESCRIPTION
`getConnection()` is now centralized in a new class called `SchematicUtil`. None of the existing classes in the backend seemed like a good fit for this function so I made a new utility class.

Resolves issue #11 
