### PR TITLE
Revive args tests and gitignore the outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ nbproject/private/
 *.out
 /bin
 
+## Outputs not used in acceptance tests
+/*.mo
+/*.smt2
+

--- a/src/test/java/org/manifold/compiler/back/microfluidics/TestMicrofluidicsBackend.java
+++ b/src/test/java/org/manifold/compiler/back/microfluidics/TestMicrofluidicsBackend.java
@@ -32,6 +32,66 @@ public class TestMicrofluidicsBackend {
     
     UtilSchematicConstruction.setupIntermediateTypes();
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOptionProcessParameters_FromCLI_MissingOptions()
+      throws Exception {
+    MicrofluidicsBackend backend = new MicrofluidicsBackend();
+    String[] args = {
+        "-bProcessMinimumNodeDistance", "0.0001",
+        "-bProcessMinimumChannelLength", "0.0001",
+        "-bProcessMaximumChipSizeX", "0.04",
+        "-bProcessMaximumChipSizeY", "0.04",
+        //"-bProcessCriticalCrossingAngle", "0.0872664626" // leave out
+    };
+    Schematic schematic = UtilSchematicConstruction
+        .instantiateSchematic("empty");
+
+    Options options = new Options();
+    backend.registerArguments(options);
+    CommandLineParser parser = new org.apache.commons.cli.BasicParser();
+    CommandLine cmd = parser.parse(options, args);
+    backend.invokeBackend(schematic, cmd);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOptionProcessParameters_FromCLI_NotANumber()
+          throws Exception {
+    MicrofluidicsBackend backend = new MicrofluidicsBackend();
+    String[] args = {
+        "-bProcessMinimumNodeDistance", "foo",
+        "-bProcessMinimumChannelLength", "bar",
+        "-bProcessMaximumChipSizeX", "baz",
+        "-bProcessMaximumChipSizeY", "doge",
+        "-bProcessCriticalCrossingAngle", "wow"
+    };
+    Schematic schematic = UtilSchematicConstruction
+        .instantiateSchematic("empty");
+
+    Options options = new Options();
+    backend.registerArguments(options);
+    CommandLineParser parser = new org.apache.commons.cli.BasicParser();
+    CommandLine cmd = parser.parse(options, args);
+    backend.invokeBackend(schematic, cmd);
+  }
+
+  @Test
+  public void testInvokeBackend_EmptySchematic()
+      throws Exception {
+    MicrofluidicsBackend backend = new MicrofluidicsBackend();
+    String[] args = {
+        "-bProcessMinimumNodeDistance", "0.0001",
+        "-bProcessMinimumChannelLength", "0.0001",
+        "-bProcessMaximumChipSizeX", "0.04",
+        "-bProcessMaximumChipSizeY", "0.04",
+        // both single and double dash are correct
+        "--bProcessCriticalCrossingAngle", "0.0872664626"
+    };
+    Schematic schematic = UtilSchematicConstruction
+            .instantiateSchematic("empty");
+
+    runAcceptanceTest(schematic, args);
+  }
   
   @Test
   public void testSimpleSynthesis() throws Exception {
@@ -144,10 +204,6 @@ public class TestMicrofluidicsBackend {
         new String(encoded, Charset.defaultCharset()));
     }
 
-    if (Files.exists(actualOutputPath)) {
-      Files.delete(actualOutputPath);
-    }
-
     if (expectedFileContents != null) {
       if (!expectedFileContents.equals(actualFileContents)) {
         FileWriter fileWriter = new FileWriter(errorPath.toFile());
@@ -188,66 +244,5 @@ public class TestMicrofluidicsBackend {
   private String normalizeLineEndings(String fileContents) {
     return fileContents.replaceAll("\\r\\n?", "\n");
   }
-  
-  // TODO update test for new interface
-  /*
-  @Test
-  public void testOptionProcessParameters_FromCLI() 
-      throws ParseException, IOException {
-    MicrofluidicsBackend backend = new MicrofluidicsBackend();
-    String[] args = {
-      "-bProcessMinimumNodeDistance", "0.0001",
-      "-bProcessMinimumChannelLength", "0.0001",
-      "-bProcessMaximumChipSizeX", "0.04",
-      "-bProcessMaximumChipSizeY", "0.04",
-      // both single and double dash are correct
-      "--bProcessCriticalCrossingAngle", "0.0872664626"
-    };
-    backend.readArguments(args);
-  }
-  
-  @Test(expected = IllegalArgumentException.class)
-  public void testOptionProcessParameters_FromCLI_MissingOptions() 
-      throws ParseException, IOException {
-    MicrofluidicsBackend backend = new MicrofluidicsBackend();
-    String[] args = {
-      "-bProcessMinimumNodeDistance", "0.0001",
-      "-bProcessMinimumChannelLength", "0.0001",
-      "-bProcessMaximumChipSizeX", "0.04",
-      "-bProcessMaximumChipSizeY", "0.04",
-      //"-bProcessCriticalCrossingAngle", "0.0872664626" // leave out
-    };
-    backend.readArguments(args);
-  }
-  
-  @Test(expected = IllegalArgumentException.class)
-  public void testOptionProcessParameters_FromCLI_NotANumber() 
-      throws ParseException, IOException {
-    MicrofluidicsBackend backend = new MicrofluidicsBackend();
-    String[] args = {
-      "-bProcessMinimumNodeDistance", "foo",
-      "-bProcessMinimumChannelLength", "bar",
-      "-bProcessMaximumChipSizeX", "baz",
-      "-bProcessMaximumChipSizeY", "doge",
-      "-bProcessCriticalCrossingAngle", "wow"
-    };
-    backend.readArguments(args);
-  }
-  
-  @Test
-  public void testInvokeBackend_EmptySchematic() 
-      throws Exception {
-    MicrofluidicsBackend backend = new MicrofluidicsBackend();
-    String[] args = {
-      "-bProcessMinimumNodeDistance", "0.0001",
-      "-bProcessMinimumChannelLength", "0.0001",
-      "-bProcessMaximumChipSizeX", "0.04",
-      "-bProcessMaximumChipSizeY", "0.04",
-      "-bProcessCriticalCrossingAngle", "0.0872664626"
-    };
-    Schematic schematic = UtilSchematicConstruction
-        .instantiateSchematic("test");
-    backend.invokeBackend(schematic, args); 
-  }
-  */
+
 }

--- a/src/test/java/org/manifold/compiler/back/microfluidics/acceptance/empty.mo
+++ b/src/test/java/org/manifold/compiler/back/microfluidics/acceptance/empty.mo
@@ -1,0 +1,34 @@
+model Main
+	import Modelica.Constants.inf;
+	import Pi=Modelica.Constants.pi;
+	import Modelica.Constants.pi;
+	import Maplesoft.Constants.I;
+
+equation
+annotation(
+Diagram(coordinateSystem(preserveAspectRatio=true, extent={{0,0},{500.0,500.0}}),graphics),
+Icon(coordinateSystem(preserveAspectRatio=true, extent={{0,0},{200.0,200.0}}),graphics={Rectangle(extent={{0,0},{200.0,200.0}}, lineColor={0,0,0}),Rectangle(extent={{0.0,0.0},{200.0,200.0}})}),
+uses(Modelica(version="3.2.1")),
+experiment( StartTime = 0,
+StopTime = 10.0,
+__Maplesoft_solver = "ck45",
+__Maplesoft_adaptive = true,
+__Maplesoft_engine = 2,
+Tolerance = 0.10e-4,
+__Maplesoft_tolerance_abs = 0.10e-4,
+__Maplesoft_step_size = 0.10e-2,
+__Maplesoft_plot_points = 200,
+__Maplesoft_numeric_jacobian = false,
+__Maplesoft_constraint_iterations = 50,
+__Maplesoft_event_iterations = 100,
+__Maplesoft_algebraic_error_control = false,
+__Maplesoft_algebraic_error_relaxation_factor = 1.0,
+__Maplesoft_rate_hysteresis = 0.10e-9,
+__Maplesoft_scale_method = "none",
+__Maplesoft_reduce_events = false,
+__Maplesoft_integration_diagnostics = false,
+__Maplesoft_plot_event_points = true,
+__Maplesoft_compiler = true,
+__Maplesoft_compiler_optimize = true
+));
+end Main;

--- a/src/test/java/org/manifold/compiler/back/microfluidics/acceptance/empty.smt2
+++ b/src/test/java/org/manifold/compiler/back/microfluidics/acceptance/empty.smt2
@@ -1,0 +1,5 @@
+( set-logic QF_NRA )
+( declare-fun PI ( ) Real )
+( assert ( = PI 3.141592653589793 ) )
+( check-sat )
+( exit )


### PR DESCRIPTION
The tests were originally commented out because they did not comply with the new interface for listing args and invoking the backend.

The new `.gitignore` lines apply only to the root directory. This is to stop regular .smt2 and .mo outputs from being added to git while allowing acceptance test .smt2 and .mo files (which are in a non-root folder) to be part of the repo.